### PR TITLE
Allow multiple images in MiniCPM-V

### DIFF
--- a/endpoint.py
+++ b/endpoint.py
@@ -104,7 +104,7 @@ class MiniCPMDeployment:
     async def image_infer(
         self,
         # Accept args and kwargs as JSON:
-        image_files: list[UploadFile],
+        image_files: list[UploadFile] = File([]),
         json_messages: str = Form(...),
         json_kwargs: str = Form(...),
     ):

--- a/endpoint.py
+++ b/endpoint.py
@@ -110,7 +110,9 @@ class MiniCPMDeployment:
     ):
         # Deserialize the JSON string into a list of dictionaries
         try:
-            messages: list = json.loads(json_messages)  # Convert the JSON string to a list
+            messages: list = json.loads(
+                json_messages
+            )  # Convert the JSON string to a list
             kwargs: dict = json.loads(json_kwargs)
         except json.JSONDecodeError:
             raise HTTPException(
@@ -127,8 +129,13 @@ class MiniCPMDeployment:
                 for item in message["content"]:
                     if type(item) is int:
                         if item not in range(len(image_files)):
-                            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Image indices must be 0-based, in range of total uploaded image files")
-                        processed_content.append(Image.open(image_files[item].file).convert("RGB"))
+                            raise HTTPException(
+                                status_code=HTTPStatus.BAD_REQUEST,
+                                detail="Image indices must be 0-based, in range of total uploaded image files",
+                            )
+                        processed_content.append(
+                            Image.open(image_files[item].file).convert("RGB")
+                        )
                     else:
                         processed_content.append(item)
                 processed_message["content"] = processed_content


### PR DESCRIPTION
Multiple images can be used in a conversation; they are inserted using their index in the list of images in which they are uploaded, e.g.:

```json
[{"type": "text", "role": "user", "content": [0, 1, 2, 0, "Which of these photographs is duplicated?"]}]
```

![image](https://github.com/user-attachments/assets/72c0bfb5-9ef2-4d89-b3c9-976711a0f58d)
