### PR TITLE
Don't bump version

### DIFF
--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -8,7 +8,7 @@ jobs:
   bump-release:
     if: github.base_ref == 'main' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    name: Bump version & push tag
+    name: Push version tag
     permissions:
       contents: write
     env:
@@ -32,13 +32,3 @@ jobs:
           export VERSION="$(poetry version -s)"
           git tag $VERSION
           git push origin tag $VERSION
-
-      - name: Bump version
-        run: |
-          poetry version patch
-
-      - name: Commit bumped version
-        run: |
-          git add pyproject.toml
-          git commit -am "Auto-bump version"
-          git push origin HEAD:${{ github.base_ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elevaite-inference"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Connor Boyle", "Korinayo Thompson"]
 description = "Inference working directory for ElevAIte"
 


### PR DESCRIPTION
I can't get version bumping on a protected branch to work (I suppose I could get this to work on `bracket-ai/elevaite` if I just make `dev` a non-protected branch, though)